### PR TITLE
refactor: make signin format same with SuccessResponseDTO

### DIFF
--- a/src/integrationTest/kotlin/com/group4/ticketingservice/User/UserControllerTest.kt
+++ b/src/integrationTest/kotlin/com/group4/ticketingservice/User/UserControllerTest.kt
@@ -79,7 +79,7 @@ class UserControllerTest : AbstractIntegrationTest() {
                 .contentType(MediaType.APPLICATION_JSON)
         ).andReturn()
         val jwt = gson.fromJson(result.response.contentAsString, JsonObject::class.java)
-        return jwt.get("Authorization").asString
+        return (jwt.get("data") as JsonObject).get("Authorization").asString
     }
 
     @Test

--- a/src/main/kotlin/com/group4/ticketingservice/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/group4/ticketingservice/filter/JwtAuthenticationFilter.kt
@@ -9,11 +9,11 @@ import com.group4.ticketingservice.utils.TokenProvider
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import java.io.PrintWriter
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import java.io.PrintWriter
 
 class JwtAuthenticationFilter(
     private val authenticationManager: AuthenticationManager?,
@@ -42,13 +42,14 @@ class JwtAuthenticationFilter(
         chain: FilterChain,
         authResult: Authentication
     ) {
-
         val user = authResult.principal as User
         val jwt = tokenProvider.createToken("${user.id}")
-        val body = gson.toJson(SuccessResponseDTO(
+        val body = gson.toJson(
+            SuccessResponseDTO(
                 path = request.requestURI,
-                data =mapOf("Authorization" to "Bearer $jwt")
-        ))
+                data = mapOf("Authorization" to "Bearer $jwt")
+            )
+        )
 
         response.contentType = "application/json"
         val writer: PrintWriter = response.writer

--- a/src/main/kotlin/com/group4/ticketingservice/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/group4/ticketingservice/filter/JwtAuthenticationFilter.kt
@@ -3,16 +3,17 @@ package com.group4.ticketingservice.filter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.gson.Gson
 import com.group4.ticketingservice.dto.SignInRequest
+import com.group4.ticketingservice.dto.SuccessResponseDTO
 import com.group4.ticketingservice.entity.User
 import com.group4.ticketingservice.utils.TokenProvider
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import java.io.PrintWriter
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import java.io.PrintWriter
 
 class JwtAuthenticationFilter(
     private val authenticationManager: AuthenticationManager?,
@@ -41,9 +42,14 @@ class JwtAuthenticationFilter(
         chain: FilterChain,
         authResult: Authentication
     ) {
+
         val user = authResult.principal as User
         val jwt = tokenProvider.createToken("${user.id}")
-        val body = gson.toJson(mapOf("Authorization" to "Bearer $jwt"))
+        val body = gson.toJson(SuccessResponseDTO(
+                path = request.requestURI,
+                data =mapOf("Authorization" to "Bearer $jwt")
+        ))
+
         response.contentType = "application/json"
         val writer: PrintWriter = response.writer
         writer.println(body)


### PR DESCRIPTION
#  What is this PR?
- Github Issue: #117


# Key Changes
Filter단 에서 request처리가 끝나 ResponseAdvice에 적용을을 못받는 엔드포인트에 대해 
SuccessResponseDTO 형식을 수동으로 맞추어줌

# Test Checklist
